### PR TITLE
Added googleVisionApi wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 public/uploads/
 .idea/
+privateConfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 public/uploads/
+.idea/

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5831,7 +5831,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5849,11 +5850,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5866,15 +5869,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5977,7 +5983,8 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5987,6 +5994,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5999,17 +6007,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6026,6 +6037,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -6081,7 +6093,8 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -6106,7 +6119,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6116,6 +6130,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6184,7 +6199,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6214,6 +6230,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6231,6 +6248,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6269,11 +6287,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -13336,6 +13356,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "url-loader": {
       "version": "2.3.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13357,11 +13357,6 @@
         }
       }
     },
-    "url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
-    },
     "url-loader": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-2.3.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,8 @@
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.4.1"
+    "react-scripts": "3.4.1",
+    "url-join": "^4.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/package.json
+++ b/client/package.json
@@ -13,8 +13,7 @@
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",
-    "react-scripts": "3.4.1",
-    "url-join": "^4.0.1"
+    "react-scripts": "3.4.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/googleVisionApi.js
+++ b/googleVisionApi.js
@@ -5,17 +5,19 @@ export class GoogleVisionApi {
     static apiKey = "?key=AIzaSyB5WVcfCzsxhCRfh34jTiubDyEOnP5pXYc";
     static requestURL = urljoin(GoogleVisionApi.imageRecognitionURL, GoogleVisionApi.apiKey);
     static async postImage(base64StringOfImage, type = "LABEL_DETECTION", maxResults = 5) {
-        const requestBody = [
-            {
-                image: { content: base64StringOfImage }, // Example of converting a buffer to base64string: Buffer.from(fs.readFileSync(imagePath)).toString("base64")
-                features: [
-                    {
-                        type: type,
-                        maxResults: maxResults
-                    }
-                ]
-            }
-        ];
+        const requestBody = {
+            requests: [
+                {
+                    image: { content: base64StringOfImage }, // Example of converting a buffer to base64string: Buffer.from(fs.readFileSync(imagePath)).toString("base64")
+                    features: [
+                        {
+                            type: type,
+                            maxResults: maxResults
+                        }
+                    ]
+                }
+            ]
+        };
 
         const response = await fetch(GoogleVisionApi.requestURL, {
             method: 'POST',
@@ -25,6 +27,6 @@ export class GoogleVisionApi {
             body: JSON.stringify(requestBody)
         });
 
-        return await response.json();
+        return response.json();
     }
 }

--- a/googleVisionApi.js
+++ b/googleVisionApi.js
@@ -3,7 +3,7 @@ import urljoin from 'url-join';
 export class GoogleVisionApi {
     static imageRecognitionURL = "https://vision.googleapis.com/v1/images:annotate";
     static apiKey = "?key=AIzaSyB5WVcfCzsxhCRfh34jTiubDyEOnP5pXYc";
-    static requestURL = urljoin(ApiHelper.imageRecognitionURL, ApiHelper.apiKey);
+    static requestURL = urljoin(GoogleVisionApi.imageRecognitionURL, GoogleVisionApi.apiKey);
     static async postImage(base64StringOfImage, type = "LABEL_DETECTION", maxResults = 5) {
         const requestBody = [
             {
@@ -17,7 +17,7 @@ export class GoogleVisionApi {
             }
         ];
 
-        const response = await fetch(ApiHelper.requestURL, {
+        const response = await fetch(GoogleVisionApi.requestURL, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'

--- a/googleVisionApi.js
+++ b/googleVisionApi.js
@@ -1,8 +1,8 @@
-import urljoin from 'url-join';
-
-export class GoogleVisionApi {
+const urljoin = require('url-join');
+const config = require('./privateConfig');
+class GoogleVisionApi {
     static imageRecognitionURL = "https://vision.googleapis.com/v1/images:annotate";
-    static apiKey = "?key=AIzaSyB5WVcfCzsxhCRfh34jTiubDyEOnP5pXYc";
+    static apiKey = "?key=" + config.googleVisionApiKey;
     static requestURL = urljoin(GoogleVisionApi.imageRecognitionURL, GoogleVisionApi.apiKey);
     static async postImage(base64StringOfImage, type = "LABEL_DETECTION", maxResults = 5) {
         const requestBody = {
@@ -30,3 +30,5 @@ export class GoogleVisionApi {
         return response.json();
     }
 }
+
+module.exports = GoogleVisionApi;

--- a/googleVisionApi.js
+++ b/googleVisionApi.js
@@ -1,0 +1,30 @@
+import urljoin from 'url-join';
+
+export class GoogleVisionApi {
+    static imageRecognitionURL = "https://vision.googleapis.com/v1/images:annotate";
+    static apiKey = "?key=AIzaSyB5WVcfCzsxhCRfh34jTiubDyEOnP5pXYc";
+    static requestURL = urljoin(ApiHelper.imageRecognitionURL, ApiHelper.apiKey);
+    static async postImage(base64StringOfImage, type = "LABEL_DETECTION", maxResults = 5) {
+        const requestBody = [
+            {
+                image: { content: base64StringOfImage }, // Example of converting a buffer to base64string: Buffer.from(fs.readFileSync(imagePath)).toString("base64")
+                features: [
+                    {
+                        type: type,
+                        maxResults: maxResults
+                    }
+                ]
+            }
+        ];
+
+        const response = await fetch(ApiHelper.requestURL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(requestBody)
+        });
+
+        return await response.json();
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1775,6 +1775,11 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "express": "^4.16.4",
     "multer": "^1.4.2",
     "node-fetch": "^2.6.0",
-    "react-bootstrap": "^1.0.1"
+    "react-bootstrap": "^1.0.1",
+    "url-join": "^4.0.1"
   },
   "devDependencies": {
     "concurrently": "^4.0.1"

--- a/server.js
+++ b/server.js
@@ -4,12 +4,10 @@ const path = require("path");
 const multer = require("multer");
 const vision = require('@google-cloud/vision');
 
-
 const client = new vision.ImageAnnotatorClient();
 
 const app = express();
 const port = process.env.PORT || 5000;
-
 
 // UPLOAD REQUEST
 const storage = multer.diskStorage({


### PR DESCRIPTION
After the client has uploaded an image, you have to convert the image to a base64 encoded string. Additionally, when the player wants to use an image from the raspicam, the node server can read from the raspberry pi filesystem where the raspicam stores the current image and load the image. After that you can call the GoogleVisionApi like this:

``` javascript
const GoogleVisionApi = require("GoogleVisionApi.js");
// just a generic async function
async function(image) {
    const json = await GoogleVisionApi.postImage(image);
    console.log(json.responses[0].labelAnnotations);
};
```

The `privateConfig.json` file looks like this:
``` json
{
  "googleVisionApiKey": "apiKey"
}
```